### PR TITLE
Compatibility issue with BA

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,4 +1,9 @@
 ---------------------------------------------------------------------------------------------------
+Version: 1.2.11
+Date: ???
+  Bugfixes:
+    - Fixed compatibility issue with Bob's Technology mod and Technology Overhaul setting from Angel's Industries mod
+---------------------------------------------------------------------------------------------------
 Version: 1.2.10
 Date: 13.01.2024
   Features:

--- a/info.json
+++ b/info.json
@@ -1,6 +1,6 @@
 {
   "name": "SpaceModFeorasFork",
-  "version": "1.2.10",
+  "version": "1.2.11",
   "title": "Space Extension Mod (Feoras Fork)",
   "author": "Feoras",
   "description": "Greatly extend the end game requiring multiple launches, massively increased science and item production. Requires a few hundred launches with a variety of new components. The goal is to build a vessel capable of getting you off the planet and home safely.",

--- a/prototypes/technology-bobs.lua
+++ b/prototypes/technology-bobs.lua
@@ -28,7 +28,7 @@ local SpaceXTechs = {
 	"space-cartography",
 }
 
-if data.raw.tool["advanced-logistic-science-pack"] then
+if bobmods.tech and bobmods.tech.advanced_logistic_science then
 
 	-- Bob exclusive FTL Theory D
 	table.insert(SpaceXTechs, "ftl-theory-D")


### PR DESCRIPTION
When Angel's Industries mod setting "Technology Overhaul" is enabled, regular science packs should not be used. The SpaceX techs can't be researched as they use the pink "Logistic Science Pack".

![image](https://github.com/user-attachments/assets/2f58e386-a0fd-4fa2-be89-2c3cc14a8c9d)

Minimum mod list:
- Angel's Bioprocessing
- Angel's Industries (tech overhaul)
- Angel's Petrochemical Processing
- Angel's Refining
- Angel's Smelting
- Bob's Electronics
- Bob's Functions Library
- Bob's Logistics
- Bob's Metals, Chemicals, and Intermediates
- Bob's Modules
- Bob's Ores
- Bob's Personal Equipment
- Bob's Technology
- Space Extension Mod (Feoras Fork)

Issue was reported again on the Angel's GitHub. I submitted a PR to fix it to SpaceMod back in February. Still no updates there so hopefully it can be fixed in this fork at least!

https://github.com/Arch666Angel/mods/issues/993
https://github.com/billbo99/SpaceMod/pull/1